### PR TITLE
Prevent permission overwrite update unless user switches channels

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -30,6 +30,9 @@ client.on("message", (message) => {
 });
 
 client.on("voiceStateUpdate", (oldState, newState) => {
+  if(oldState.channelID === newState.channelID)
+    return
+
   if (oldState.channelID !== null) {
     const collection = db.db("channels").collection("vc-text-link");
     collection.findOne({ voice: oldState.channelID }).then((res) => {

--- a/bot.js
+++ b/bot.js
@@ -30,7 +30,7 @@ client.on("message", (message) => {
 });
 
 client.on("voiceStateUpdate", (oldState, newState) => {
-  if(oldState.channelID === newState.channelID)
+  if (oldState.channelID === newState.channelID)
     return
 
   if (oldState.channelID !== null) {


### PR DESCRIPTION
Ignore VOICE_STATE_UPDATE event if the user did not switch channels (e.g. user mutes/unmutes, deafens/undeafens, enables/disables camera, starts/ends screensharing).